### PR TITLE
added kafka minion as a prometheus exporter

### DIFF
--- a/ansible/roles/kafka-logging-setup/files/minion_pod.yaml
+++ b/ansible/roles/kafka-logging-setup/files/minion_pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata: 
+  name: kafka-minion
+  labels:
+    kafka: minion
+spec:
+  securityContext:
+    runAsUser: 99
+  containers:
+  - env:
+    - name: KAFKA_BROKERS
+      value: my-cluster-kafka-bootstrap.amq.svc:9093
+    - name: KAFKA_TLS_ENABLED
+      value: "true"
+    image:  quay.io/google-cloud-tools/kafka-minion:v1.0.0 
+    imagePullPolicy: Always
+    name: kafka-minion
+    restartPolicy: Always
+

--- a/ansible/roles/kafka-logging-setup/files/minion_service.yaml
+++ b/ansible/roles/kafka-logging-setup/files/minion_service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-minion
+spec:
+  selector:
+    kafka: minion
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080

--- a/ansible/roles/kafka-logging-setup/tasks/main.yml
+++ b/ansible/roles/kafka-logging-setup/tasks/main.yml
@@ -51,5 +51,14 @@
   with_items:
     - cr-logforwarding-to-kafka-topics.yaml
 
+- name: Deploy the kafka-minion pod and service
+  k8s:
+    state: present
+    namespace: "amq"
+    definition: "{{ lookup('file', item ) }}"
+  with_items:
+    - minion_pod.yaml 
+    - minion_service.yaml
+
 # TODO
 # Wait and Check if all resources are ready


### PR DESCRIPTION
This adds kafka-minion as a prom exporter, so we can make use of the exported kafka metrics.