### PR TITLE
Allow the managed cluster vendor label to be configured.

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -36,6 +36,7 @@ rhacm_version: 2.1
 rhacm_redisgraph_memory_limit: "3Gi"
 hub_cluster_kubeconfig: /home/stack/ocp_clusters/vlan608/auth/kubeconfig
 managed_cluster_name: shiftstack0000
+managed_cluster_vendor: OpenShift
 managed_cluster_kubeconfig: "/home/stack/ocp_clusters/{{managed_cluster_name}}/auth/kubeconfig"
 
 ################################################################################

--- a/ansible/roles/rhacm_manage_cluster/templates/hub.yml.j2
+++ b/ansible/roles/rhacm_manage_cluster/templates/hub.yml.j2
@@ -11,7 +11,7 @@ kind: ManagedCluster
 metadata:
   name: "{{managed_cluster_name}}"
   labels:
-    vendor: OpenShift
+    vendor: "{{managed_cluster_vendor}}"
 spec:
   hubAcceptsClient: true
 ---


### PR DESCRIPTION
In the event we have kind clusters and obs deployed, we need to make
sure we configure the vendor label to avoid obs agents from deploying
automatically.