### PR TITLE
Local-storage depends on the release version vars

### DIFF
--- a/ansible/local-storage.yml
+++ b/ansible/local-storage.yml
@@ -11,5 +11,8 @@
   hosts: orchestration
   vars_files:
     - vars/all.yml
+  pre_tasks:
+    - name: run validations
+      include_tasks: tasks/validation.yml
   roles:
     - local_storage


### PR DESCRIPTION
Thus the validation tasks must run to have that operator install according to this pattern.