### PR TITLE
CI fixes 

### DIFF
--- a/ansible/roles/aspenmesh-servicemesh-setup/tasks/main.yml
+++ b/ansible/roles/aspenmesh-servicemesh-setup/tasks/main.yml
@@ -36,6 +36,9 @@
     copy:
       src: "{{ work_dir.path }}/linux-386/helm"
       dest: "/usr/local/bin"
+      mode: 0755
+      remote_src: yes
+    become: true
   when: "'command not found' in helm_check.stderr"
 
 - name: Download Aspenmesh

--- a/ansible/roles/kafka-logging-setup/tasks/main.yml
+++ b/ansible/roles/kafka-logging-setup/tasks/main.yml
@@ -1,4 +1,20 @@
 ---
+- name: Create temp directory for dittybopper
+  tempfile:
+    state: directory
+  register: ditty_tempdir
+
+- name: Download performance-dashboard
+  git:
+    repo: https://github.com/cloud-bulldozer/performance-dashboards.git
+    dest: "{{ ditty_tempdir.path }}/performance-dashboards"
+    force: true
+
+- name: Install dittybopper
+  shell: ./deploy.sh
+  args:
+    chdir: "{{ ditty_tempdir.path }}/performance-dashboards/dittybopper"
+
 - name: Deploy Kafka cluster with ephemeral storage
   k8s:
     state: present

--- a/ansible/roles/trident-storage-setup/tasks/10-cleanup-vm.yml
+++ b/ansible/roles/trident-storage-setup/tasks/10-cleanup-vm.yml
@@ -1,3 +1,21 @@
+- name: Delete test pod
+  shell: |
+    oc delete pod redis-test-pod -n trident --force
+  ignore_errors: true
+
+- name: Delete test pvc
+  shell: |
+    oc delete pvc redis-pvc -n trident --force
+  ignore_errors: true
+
+- name: Delete test sc
+  k8s:
+    state: absent
+    force: yes
+    api_version: storage.k8s.io/v1
+    kind: StorageClass
+    name: ontap-sc
+
 - name: Get list of all VMs
   virt:
     command: list_vms


### PR DESCRIPTION
- Installing `dittybopper` as it is required for kafka installation
- Cleanup trident test pods before deleting storage.
- File privilege change for helm binary