### PR TITLE
Update kafka to 2.7.0 as 2.5.0 is deprecated

### DIFF
--- a/ansible/roles/kafka-logging-setup/files/consumer_alerts.yaml
+++ b/ansible/roles/kafka-logging-setup/files/consumer_alerts.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: alerts-consumer
-        image: "registry.redhat.io/amq7/amq-streams-kafka-25-rhel7@sha256:e719f662bd4d6b8c54b1ee2e47c51f8d75a27a238a51d9ee38007187b3a627a4"
+        image: registry.redhat.io/amq7/amq-streams-kafka-27-rhel7:1.7.0
         command: ["bin/kafka-console-consumer.sh","--bootstrap-server", "my-cluster-kafka-bootstrap:9092", "--topic", "topic-logging-alerts", "--group", "alerts-consumer", "--from-beginning"]
       restartPolicy: Never
 

--- a/ansible/roles/kafka-logging-setup/files/consumer_apps.yaml
+++ b/ansible/roles/kafka-logging-setup/files/consumer_apps.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: apps-consumer
-        image: "registry.redhat.io/amq7/amq-streams-kafka-25-rhel7@sha256:e719f662bd4d6b8c54b1ee2e47c51f8d75a27a238a51d9ee38007187b3a627a4"
+        image: registry.redhat.io/amq7/amq-streams-kafka-27-rhel7:1.7.0
         command: ["bin/kafka-console-consumer.sh","--bootstrap-server", "my-cluster-kafka-bootstrap:9092", "--topic", "topic-logging-apps", "--group", "apps-consumer", "--from-beginning"]
       restartPolicy: Never
 

--- a/ansible/roles/kafka-logging-setup/files/consumer_infra.yaml
+++ b/ansible/roles/kafka-logging-setup/files/consumer_infra.yaml
@@ -8,6 +8,6 @@ spec:
     spec:
       containers:
       - name: infra-consumer
-        image: "registry.redhat.io/amq7/amq-streams-kafka-25-rhel7@sha256:e719f662bd4d6b8c54b1ee2e47c51f8d75a27a238a51d9ee38007187b3a627a4"
+        image: registry.redhat.io/amq7/amq-streams-kafka-27-rhel7:1.7.0
         command: ["bin/kafka-console-consumer.sh","--bootstrap-server", "my-cluster-kafka-bootstrap:9092", "--topic", "topic-logging-infra", "--group", "infra-consumer", "--from-beginning"]
       restartPolicy: Never

--- a/ansible/roles/kafka-logging-setup/files/kafka-cluster-ephemeral.yaml
+++ b/ansible/roles/kafka-logging-setup/files/kafka-cluster-ephemeral.yaml
@@ -26,7 +26,7 @@ spec:
     replicas: 3
     storage:
       type: ephemeral
-    version: 2.5.0
+    version: 2.7.0
   zookeeper:
     replicas: 3
     storage:

--- a/ansible/roles/kafka-logging-setup/files/kafka-cluster-persistent.yaml
+++ b/ansible/roles/kafka-logging-setup/files/kafka-cluster-persistent.yaml
@@ -45,7 +45,7 @@ spec:
       size: 100Gi
       deleteClaim: false
       class: kafka-local-brokers
-    version: 2.5.0
+    version: 2.7.0
   zookeeper:
     NodeSelector:
       nodeSelectorTerms:


### PR DESCRIPTION
Can parameterize in future, but doesn't seem necessary now
as it works on OCP 4.6.28 when tested.

Currently the kafka brokers/zoopkeeper never get created
if using version 2.5.0

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>