### PR TITLE
Added SCTP setup

### DIFF
--- a/ansible/group_vars/all.yml.sample
+++ b/ansible/group_vars/all.yml.sample
@@ -222,3 +222,8 @@ max_pods: 500
 # and Hugepages
 perf_mcp_selector: "pools.operator.machineconfiguration.openshift.io/master: "
 perf_node_selector: "node-role.kubernetes.io/master: "
+
+################################################################################
+# SCTP setup
+################################################################################
+sctp_enable: false

--- a/ansible/roles/sctp-setup/tasks/main.yml
+++ b/ansible/roles/sctp-setup/tasks/main.yml
@@ -1,0 +1,29 @@
+- name: Create MachineConfig for loading SCTP module
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'load-sctp-module.yaml.j2') }}"
+  register: sctp_mc
+
+- name: Wait for SCTP MachineConfig to be applied
+  block:
+    - name: Wait for worker MCP to start updating
+      shell: |
+        oc wait --for=condition=Updating --timeout=300s mcp worker
+      register: mcp_updating
+      changed_when: "'condition met' in mcp_updating.stdout"
+      retries: 3 # 3 minutes * 5 minutes (timeout)
+      delay: 60
+      until: mcp_updating is success
+      ignore_errors: true
+
+    - name: Wait for worker MCP to be updated
+      shell: |
+        oc wait --for=condition=Updated --timeout=1800s mcp worker
+      changed_when: false
+      register: worker_update
+      retries: 3 # 3 minutes * 30 minutes (timeout)
+      delay: 60
+      until: not worker_update.failed
+      when: mcp_updating is changed
+  when:
+    - sctp_mc is changed

--- a/ansible/roles/sctp-setup/templates/load-sctp-module.yaml.j2
+++ b/ansible/roles/sctp-setup/templates/load-sctp-module.yaml.j2
@@ -1,0 +1,22 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: load-sctp-module
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+        - path: /etc/modprobe.d/sctp-blacklist.conf
+          mode: 0644
+          overwrite: true
+          contents:
+            source: data:,
+        - path: /etc/modules-load.d/sctp-load.conf
+          mode: 0644
+          overwrite: true
+          contents:
+            source: data:,sctp

--- a/ansible/webscale.yml
+++ b/ansible/webscale.yml
@@ -19,6 +19,10 @@
   vars_files:
     - vars/all.yml
   roles:
+    - role: sctp-setup
+      when: sctp_enable
+      tags: sctp
+
     - role: label_node
       when: label_node_values is defined and label_node_values | length > 0
 


### PR DESCRIPTION
New role for SCTP setup
Notes:
 - SCTP is disabled by default
 - SCTP role is executed first because the lesser pods the quicker to drain the workers. Also, I have seen errors when trying to evict nodes with aspen-mesh already installed: 
    ` Node worker000-5039ms is reporting: "failed to drain node (5 tries): timed out waiting for the condition: [error when waiting for pod \"istiod-cassandra-1\" terminating: global timeout reached: 1m30s, error when waiting for pod \"aspen-mesh-alertmanager-6858c645d5-tr7w6\" terminating: global timeout reached: 1m30s, error when waiting for pod \"aspen-mesh-event-storage-0\" terminating: global timeout reached: 1m30s, error when evicting pods/\"istio-citadel-5b478f9994-lzr8n\" -n \"istio-system\": global timeout reached: 1m30s]"`