### PR TITLE
Update agentserviceconfig.yml

### DIFF
--- a/ansible/roles/rhacm-assisted-installer/templates/agentserviceconfig.yml
+++ b/ansible/roles/rhacm-assisted-installer/templates/agentserviceconfig.yml
@@ -29,3 +29,4 @@ spec:
     version: "{{ ocp_version_rhcos_version.stdout }}"
     url: "http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_disk_location.stdout | basename }}"
     rootFSUrl: "http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_rootfs_location.stdout | basename }}"
+    cpuArchitecture: x86_64


### PR DESCRIPTION
add x86_64 for default, without this field, image url will not be downloaded. 
issue: https://bugzilla.redhat.com/show_bug.cgi?id=2004986