### PR TITLE
4.10 PAO operator channel

### DIFF
--- a/ansible/roles/operators/defaults/4.10.yml
+++ b/ansible/roles/operators/defaults/4.10.yml
@@ -18,7 +18,7 @@ ptp_channel: stable
 sriov_channel: 4.9
 
 # Performance add-on operator 
-pao_channel: 4.9
+pao_channel: "4.10"
 
 # Local Storage operator channel
 lso_channel: 4.9


### PR DESCRIPTION
The 4.9 channel does not work for 4.10 releases