### PR TITLE
updated operators channel

### DIFF
--- a/ansible/roles/operators/defaults/4.10.yml
+++ b/ansible/roles/operators/defaults/4.10.yml
@@ -3,25 +3,25 @@
 osv_channel: stable
 
 # AMQ subscription channel
-amq_channel: amq-streams-1.x
+amq_channel: amq-streams-2.x
 
 # Cluster Logging Operator channel
-cluster_logging_channel: 5.0
+cluster_logging_channel: stable-5.3
 
 # Elasticsearch Operator channel
-elasticsearch_channel: 5.0
+elasticsearch_channel: stable-5.3
 
 # Precision Time Protocol (ptp) Operator channel
 ptp_channel: stable
 
 # SR-IOV operator channel 
-sriov_channel: 4.9
+sriov_channel: "4.10"
 
 # Performance add-on operator 
 pao_channel: "4.10"
 
 # Local Storage operator channel
-lso_channel: 4.9
+lso_channel: "4.10"
 
 # To enable nightly catalog source
 nightly_operator: false

--- a/ansible/roles/operators/templates/kafka-operator.yml.j2
+++ b/ansible/roles/operators/templates/kafka-operator.yml.j2
@@ -32,6 +32,6 @@ spec:
   name: amq-streams
   source: "{{ amq_operator_source | default('redhat-operators') }}"
   sourceNamespace: openshift-marketplace
-{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 7)) %}
-  startingCSV: amqstreams.v1.7.3
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 9)) %}
+  startingCSV: amqstreams.v2.0.1-1
 {% endif %}


### PR DESCRIPTION
@mohit-sheth @mkarg75  this is the version we have [tested](http://mukrishn-newbmtest-airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/log?dag_id=4.10-baremetal-jetski&task_id=deploy-webfuse&execution_date=2022-03-11T18%3A37%3A56.745778%2B00%3A00) for 4.10.3 GA. 

