### PR TITLE
4-9 ga operator version changes

### DIFF
--- a/ansible/roles/operators/defaults/4.9.yml
+++ b/ansible/roles/operators/defaults/4.9.yml
@@ -3,13 +3,13 @@
 osv_channel: stable
 
 # AMQ subscription channel
-amq_channel: amq-streams-1.x
+amq_channel: amq-streams-2.x
 
 # Cluster Logging Operator channel
-cluster_logging_channel: 5.2
+cluster_logging_channel: stable-5.2
 
 # Elasticsearch Operator channel
-elasticsearch_channel: 5.2
+elasticsearch_channel: stable-5.2
 
 # Precision Time Protocol (ptp) Operator channel
 ptp_channel: stable


### PR DESCRIPTION
Operator version changes after GA, will help to get rid off recent 4.9 airflow job failures. 

@mkarg75  @jdowni000 please run a CI job using my fork before merge.