### PR TITLE
Install libvirt-python on rhel 8.6 , python 3.8 , ansible-core 2.12

### DIFF
--- a/ansible/roles/trident-storage-setup/tasks/main.yml
+++ b/ansible/roles/trident-storage-setup/tasks/main.yml
@@ -24,6 +24,12 @@
           disable_gpg_check: yes
         become: true
 
+      - name: Install packages
+        pip:
+          name:
+            - libvirt-python
+        become: true
+
       - name: Cleanup existing resources
         include_tasks: 10-cleanup-vm.yml
 

--- a/ansible/roles/trident-storage-setup/vars/main.yml
+++ b/ansible/roles/trident-storage-setup/vars/main.yml
@@ -4,9 +4,12 @@
 package_list:
   - tar
   - libvirt
+  - libvirt-devel
   - virt-manager
   - python3-libvirt
   - python3-lxml
   - qemu-kvm
   - qemu-img
   - patch
+  - gcc
+  - python38-devel


### PR DESCRIPTION
I am getting this error when I try and run on a RHEL8.6 VM.

ansible-core-2.12 requires and ships with python-3.8.
RHEL8.6 python3-libvirt only contains python 3.6 binaries.

These changes will install the necessary packages to run with ansible-2.12 and python-3.8