### PR TITLE
Bump aspenmesh to version 1.11.5-am2 compatible with 4.10.

### DIFF
--- a/ansible/roles/aspenmesh-servicemesh-setup/defaults/4.10.yml
+++ b/ansible/roles/aspenmesh-servicemesh-setup/defaults/4.10.yml
@@ -7,25 +7,25 @@ istio_namespace: "istio-system"
 
 helm_release: "https://get.helm.sh/helm-v3.5.2-linux-386.tar.gz"
 webfuse_images_path: "http://perf1.perf.lab.eng.bos.redhat.com/pub/dwilson/webfuse_files/"
-aspenmesh_release_file: "aspenmesh-carrier-grade-1.9.8-am1-linux.tar.gz"
+aspenmesh_release_file: "aspenmesh-carrier-grade-1.11.5-am2-linux.tar.gz"
 
 aspen_mesh_controlplane:
-  image: controlplane-1.9.8-am1
-  modelruntimeimage: modelruntime-1.9.8-am1
+  image: controlplane-1.11.5-am2
+  modelruntimeimage: modelruntime-1.11.5-am2
 
 openshift_oauthproxy:
-  image: openshift-oauth-proxy-1.9.8-am1
+  image: openshift-oauth-proxy-1.11.5-am2
 
 aspen_mesh_dashboard:
-  image: dashboard-1.9.8-am1
+  image: dashboard-1.11.5-am2
 
 aspen_mesh_secure_ingress:
-  image: secure-ingress-1.9.8-am1
+  image: secure-ingress-1.11.5-am2
 
 aspen_mesh_metrics_collector:
-  serviceimage: metrics-collector-service-1.9.8-am1
-  alertmanagerimage: alertmanager-1.9.8-am1
-  configmapreloadimage: configmap-reloader-1.9.8-am1
+  serviceimage: metrics-collector-service-1.11.5-am2
+  alertmanagerimage: alertmanager-1.11.5-am2
+  configmapreloadimage: configmap-reloader-1.11.5-am2
 
 traffic_claim_enforcer:
-  image: traffic-claim-enforcer-1.9.8-am1
+  image: traffic-claim-enforcer-1.11.5-am2


### PR DESCRIPTION
Previous version of aspenmesh used remove CRD api that will not install on OCP 4.10.